### PR TITLE
Fix failure to publish package on PR merge

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -133,7 +133,6 @@ jobs:
       run: dotnet pack -p:Version=${{ needs.version.outputs.package }}
 
     - name: Upload .NET package artefact
-      if: ${{ github.event_name != 'push' }}
       uses: actions/upload-artifact@v2
       with:
         name: package


### PR DESCRIPTION
- Fix CI/CD workflow problem where package artefact was not uploaded on pushes to main, which in turn broke package publish