### PR TITLE
Fix incorrect CI/CD badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note that this template does not include things like GitHub Actions workflows, d
 
 ## CI/CD status
 
- [![CI/CD](https://github.com/degory/ghul-console-template/workflows/CI/CD/badge.svg?branch=main)](https://github.com/degory/ghul-application-template/actions?query=workflow%3ACI%2FCD)
+ [![CI/CD](https://github.com/degory/ghul-templates/workflows/CI/CD/badge.svg?branch=main)](https://github.com/degory/ghul-templates/actions?query=workflow%3ACI%2FCD)
 
 ## Package
 


### PR DESCRIPTION
- Fix incorrect URL for CI/CD badge and link to workflow results