### PR TITLE
Clean-ups and update dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.1.0-alpha.1</Version>
+  </PropertyGroup>
+</Project>

--- a/ghul-templates.csproj
+++ b/ghul-templates.csproj
@@ -4,7 +4,7 @@
     <PackageId>ghul.templates</PackageId>
     <Title>ghūl templates</Title>
     <Authors>degory</Authors>
-    <Version>0.0.11-alpha.2</Version>
+    <PackageDescription>Templates for creating ghūl projects</PackageDescription>
     <Description>Templates for creating ghūl projects</Description>
     <PackageTags>dotnet-new;templates;ghul;ghūl;degory</PackageTags>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/templates/ghul-classlib/.config/dotnet-tools.json
+++ b/templates/ghul-classlib/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.2.154",
+      "version": "0.3.4",
       "commands": [
         "ghul-compiler"
       ]

--- a/templates/ghul-classlib/Directory.Build.props
+++ b/templates/ghul-classlib/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.1.0-alpha.1</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ghul.targets" Version="1.0.0" />
+    <PackageReference Include="ghul.pipes" Version="1.0.0" />
+    <PackageReference Include="ghul.runtime" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/templates/ghul-classlib/ghul-classlib.ghulproj
+++ b/templates/ghul-classlib/ghul-classlib.ghulproj
@@ -3,26 +3,17 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
 
-    <Title>Example ghūl class library template</Title>
-    <PackageDescription>Example ghūl programming language class library project</PackageDescription>
-    <RepositoryUrl>https://github.com/degory/ghul-templates</RepositoryUrl>
     <PackageId>example.classlib</PackageId>
-    <Authors>Some Person</Authors>
-    <Company>Some Company</Company>
-    <Version>0.0.1-alpha.1</Version>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <LicenseExpression>MIT</LicenseExpression>
 
-    <GhulCompiler>dotnet tool run ghul-compiler</GhulCompiler>
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
     <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
     <GhulSources Include="src/**/*.ghul" />
-    <None Include="README.md" Pack="true" PackagePath="\"/>
 
-    <PackageReference Include="ghul.runtime" Version="0.0.10" />
-    <PackageReference Include="ghul.pipes" Version="0.0.17" />
-    <PackageReference Include="ghul.targets" Version="0.0.6" />
+    <PackageReference Include="ghul.runtime" />
+    <PackageReference Include="ghul.pipes" />
+    <PackageReference Include="ghul.targets" />
   </ItemGroup>
 </Project>

--- a/templates/ghul-console/.config/dotnet-tools.json
+++ b/templates/ghul-console/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.2.154",
+      "version": "0.3.4",
       "commands": [
         "ghul-compiler"
       ]

--- a/templates/ghul-console/Directory.Build.props
+++ b/templates/ghul-console/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.1.0-alpha.1</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ghul.targets" Version="1.0.0" />
+    <PackageReference Include="ghul.pipes" Version="1.0.0" />
+    <PackageReference Include="ghul.runtime" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/templates/ghul-console/ghul-console.ghulproj
+++ b/templates/ghul-console/ghul-console.ghulproj
@@ -2,15 +2,14 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.0.1-alpha.1</Version>
 
-    <GhulCompiler>dotnet tool run ghul-compiler</GhulCompiler>
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
   </PropertyGroup>
 
   <ItemGroup>
     <GhulSources Include="src/**/*.ghul" />
-    <PackageReference Include="ghul.runtime" Version="0.0.10" />
-    <PackageReference Include="ghul.pipes" Version="0.0.17" />
-    <PackageReference Include="ghul.targets" Version="0.0.6" />
+    <PackageReference Include="ghul.runtime" />
+    <PackageReference Include="ghul.pipes" />
+    <PackageReference Include="ghul.targets" />
   </ItemGroup>
 </Project>

--- a/tests/ghul-classlib/.config/dotnet-tools.json
+++ b/tests/ghul-classlib/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.2.154",
+      "version": "0.3.4",
       "commands": [
         "ghul-compiler"
       ]

--- a/tests/ghul-classlib/Directory.Build.props
+++ b/tests/ghul-classlib/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="ghul.targets" Version="1.0.0" />
+    <PackageReference Include="ghul.pipes" Version="1.0.0" />
+    <PackageReference Include="ghul.runtime" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/ghul-classlib/tests.ghul
+++ b/tests/ghul-classlib/tests.ghul
@@ -1,6 +1,11 @@
 namespace ClassLibTemplate.Tests is
     entry();
 
+    // NOTE: this test does not need to be extensive or complex because
+    // we're not actually testing the example class library here - we're
+    // testing that, when the class library template is instantiated, it
+    // can be built, packaged, and consumed.
+
     class HELLO_WORLD_GREETER_Tests is
         @test()
 

--- a/tests/ghul-classlib/tests.ghulproj
+++ b/tests/ghul-classlib/tests.ghulproj
@@ -4,20 +4,20 @@
     <TargetFramework>net6.0</TargetFramework>
     <Version>0.0.1-alpha.1</Version>
 
-    <GhulCompiler>dotnet tool run ghul-compiler</GhulCompiler>
+    <GhulCompiler>dotnet ghul-compiler</GhulCompiler>
   </PropertyGroup>
 
   <ItemGroup>
     <GhulSources Include="**/*.ghul" />
 
-    <PackageReference Include="ghul.runtime" Version="0.0.10" />
-    <PackageReference Include="ghul.pipes" Version="0.0.17" />
-    <PackageReference Include="ghul.targets" Version="0.0.6" />
+    <PackageReference Include="ghul.runtime" />
+    <PackageReference Include="ghul.pipes" />
+    <PackageReference Include="ghul.targets" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
 
-    <PackageReference Include="example.classlib" Version="0.0.1-alpha.1" />
+    <PackageReference Include="example.classlib" Version="0.1.0-alpha.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Remove extraneous properties from template .ghulproj files
- Bump ghul.targets to 1.0.0
- Bump ghul.pipes to 1.0.0
- Bump ghul.runtime to 1.0.0
- Bump ghul.compiler to 0.3.4
- Bump #minor version to 0.1.0