### PR TITLE
Support .NET SDK 6.0.200

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -218,13 +218,13 @@ jobs:
 
     - name: Publish package to GitHub
       if: ${{ github.actor != 'dependabot[bot]' }}
-      run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./nupkg/*.nupkg -k ${GITHUB_TOKEN} -s https://nuget.pkg.github.com/degory/index.json --skip-duplicate --no-symbols
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish package to NuGet
       if: ${{ github.event_name == 'push' }}
-      run: dotnet nuget push ./nupkg/*.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols true
+      run: dotnet nuget push ./nupkg/*.nupkg -k ${NUGET_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.2-alpha.1</Version>
+    <Version>0.3.0-alpha.1</Version>
   </PropertyGroup>
 </Project>

--- a/templates/ghul-classlib/Directory.Build.props
+++ b/templates/ghul-classlib/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.0.0" />
+    <PackageReference Include="ghul.targets" Version="1.2.0" />
     <PackageReference Include="ghul.pipes" Version="1.0.0" />
     <PackageReference Include="ghul.runtime" Version="1.0.0" />
   </ItemGroup>

--- a/templates/ghul-console/Directory.Build.props
+++ b/templates/ghul-console/Directory.Build.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.0.0" />
+    <PackageReference Include="ghul.targets" Version="1.2.0" />
     <PackageReference Include="ghul.pipes" Version="1.0.0" />
     <PackageReference Include="ghul.runtime" Version="1.0.0" />
   </ItemGroup>

--- a/tests/ghul-classlib/Directory.Build.props
+++ b/tests/ghul-classlib/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="ghul.targets" Version="1.0.0" />
+    <PackageReference Include="ghul.targets" Version="1.2.0" />
     <PackageReference Include="ghul.pipes" Version="1.0.0" />
     <PackageReference Include="ghul.runtime" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Bump ghul.targets to 1.2.0 to fix build on .NET SDK 6.0.200
- Remove 'true' from nuget push --no-symbols parameter in CI workflow