### PR TITLE
Fix broken URLs in project file

### DIFF
--- a/ghul-templates.csproj
+++ b/ghul-templates.csproj
@@ -8,10 +8,10 @@
     <Description>Templates for creating ghūl projects</Description>
     <PackageTags>dotnet-new;templates;ghul;ghūl;degory</PackageTags>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <PackageProjectUrl>https://github.com/degory/ghul-templates</PackageProjectUrl>
+    <PackageProjectUrl>https://ghul.dev</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/degory/ghul-templates.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/degory/ghul-templates</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryBranch>main</RepositoryBranch>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>    


### PR DESCRIPTION
- Fix package project URL to point at https://ghul.dev
- Remove .git from the repository URL