### PR TITLE
Refresh templates for the current compiler and runtime

### DIFF
--- a/.dependabot/ghul-console.csproj
+++ b/.dependabot/ghul-console.csproj
@@ -1,4 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <!-- this is a .csproj wrapper for the actual .ghulproj, because Dependabot does not recognize .ghulproj as an MSBuild project file -->
-  <Import Project="templates/ghul-console/ghul-console.ghulproj" />
+  <Import Project="../templates/ghul-console/ghul-console.ghulproj" />
 </Project>

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,7 +32,7 @@ jobs:
       contents: 'write'      
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'    
 
@@ -55,7 +55,7 @@ jobs:
     needs: [version]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: .NET tool restore
       working-directory: templates/ghul-console
@@ -65,22 +65,13 @@ jobs:
       working-directory: templates/ghul-console
       run: dotnet build
 
-    - name: Run
-      id: run
+    - name: Run and verify output
       working-directory: templates/ghul-console
       run: |
         STDOUT=$(dotnet run)
-        echo "::set-output name=stdout::${STDOUT}"
+        echo "Output: ${STDOUT}"
+        test "${STDOUT}" = "Hello world!"
 
-    - name: Test
-      run: |
-        if [ "${STDOUT}" != "Hello world!" ] ; then
-          exit 1
-        fi
-
-      env:
-        STDOUT: ${{ steps.run.outputs.stdout }}
-        
   build:
     name: Build the package
     runs-on: ubuntu-latest
@@ -92,7 +83,7 @@ jobs:
     needs: [version]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Create package
       run: dotnet pack -p:Version=${{ needs.version.outputs.package }}
@@ -114,7 +105,7 @@ jobs:
     needs: [version,build]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download template package
       uses: actions/download-artifact@v4
@@ -123,7 +114,7 @@ jobs:
         path: nupkg
 
     - name: Install templates from the package
-      run: dotnet new -i nupkg/ghul.templates.${{ needs.version.outputs.package }}.nupkg
+      run: dotnet new install nupkg/ghul.templates.${{ needs.version.outputs.package }}.nupkg
       
     - name: Create project folder
       run: mkdir project
@@ -140,21 +131,12 @@ jobs:
       run: dotnet build
       working-directory: project
 
-    - name: Run
-      id: run
+    - name: Run and verify output
+      working-directory: project
       run: |
         STDOUT=$(dotnet run)
-        echo "::set-output name=stdout::${STDOUT}"
-      working-directory: project
-
-    - name: Test
-      run: |
-        if [ "${STDOUT}" != "Hello world!" ] ; then
-          exit 1
-        fi
-      working-directory: project
-      env:
-        STDOUT: ${{ steps.run.outputs.stdout }}
+        echo "Output: ${STDOUT}"
+        test "${STDOUT}" = "Hello world!"
 
   test-classlib-template:
     name: Test the classlib template
@@ -167,7 +149,7 @@ jobs:
     needs: [version,build]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download template package
       uses: actions/download-artifact@v4
@@ -176,13 +158,13 @@ jobs:
         path: nupkg
 
     - name: Install templates from the package
-      run: dotnet new -i nupkg/ghul.templates.${{ needs.version.outputs.package }}.nupkg
+      run: dotnet new install nupkg/ghul.templates.${{ needs.version.outputs.package }}.nupkg
       
     - name: Create project folder
       run: mkdir project
 
     - name: Instantiate the classlib template
-      run: dotnet new ghul-classlib
+      run: dotnet new ghul-classlib -n example.classlib -o .
       working-directory: project
 
     - name: Local .NET tools restore (template project)
@@ -215,7 +197,7 @@ jobs:
     needs: [test-console-template,test-classlib-template]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download template package
       uses: actions/download-artifact@v4
@@ -238,13 +220,18 @@ jobs:
   create_release:
     needs: [version, publish-package]
     name: Create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
     if: ${{ github.event_name == 'push' }}
 
+    permissions:
+      contents: 'write'
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
 
     - name: Download package
       uses: actions/download-artifact@v4
@@ -255,23 +242,11 @@ jobs:
     - name: Create changelog
       run: git log -1 --format="%s%n%n%b%n%n" >changelog.txt
 
-    - name: Create a Release
-      id: create_release
-      uses: actions/create-release@v1
+    - name: Create a release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ needs.version.outputs.tag }}
-        release_name: ${{ needs.version.outputs.tag }}
-        body_path: changelog.txt
-        draft: false
-
-    - name: Upload package asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./nupkg/ghul.templates.${{ needs.version.outputs.package }}.nupkg
-        asset_name: ghul.templates.${{ needs.version.outputs.package }}.nupkg
-        asset_content_type: application/octet-stream
+      run: |
+        gh release create "${{ needs.version.outputs.tag }}" \
+          ./nupkg/ghul.templates.${{ needs.version.outputs.package }}.nupkg \
+          --title "${{ needs.version.outputs.tag }}" \
+          --notes-file changelog.txt

--- a/templates/ghul-classlib/.config/dotnet-tools.json
+++ b/templates/ghul-classlib/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.8.35",
+      "version": "1.0.3",
       "commands": [
         "ghul-compiler"
       ]

--- a/templates/ghul-classlib/.template.config/template.json
+++ b/templates/ghul-classlib/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "degory",
-  "classifications": [ "Console" ], 
+  "classifications": [ "Library" ],
   "name": "ghūl class library package",
   "identity": "degory.ghūl.classlib",         
   "groupIdentity":"degory.ghūl.classlib",

--- a/templates/ghul-classlib/Directory.Packages.props
+++ b/templates/ghul-classlib/Directory.Packages.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="ghul.runtime" Version="1.3.3" />
+    <PackageVersion Include="ghul.runtime" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/templates/ghul-classlib/ghul-classlib.ghulproj
+++ b/templates/ghul-classlib/ghul-classlib.ghulproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
 
-    <PackageId>example.classlib</PackageId>
+    <PackageId>ghul-classlib</PackageId>
     <Version>0.0.1-alpha.1</Version>
 
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/templates/ghul-console/.config/dotnet-tools.json
+++ b/templates/ghul-console/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.8.35",
+      "version": "1.0.3",
       "commands": [
         "ghul-compiler"
       ]

--- a/templates/ghul-console/Directory.Packages.props
+++ b/templates/ghul-console/Directory.Packages.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="ghul.runtime" Version="1.3.3" />
+    <PackageVersion Include="ghul.runtime" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/tests/ghul-classlib/.config/dotnet-tools.json
+++ b/tests/ghul-classlib/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "ghul.compiler": {
-      "version": "0.8.35",
+      "version": "1.0.3",
       "commands": [
         "ghul-compiler"
       ]

--- a/tests/ghul-classlib/Directory.Build.props
+++ b/tests/ghul-classlib/Directory.Build.props
@@ -6,6 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="ghul.runtime" />
-    <GhulSources Include="src/**/*.ghul" />
+    <GhulSources Include="**/*.ghul" />
   </ItemGroup>
 </Project>

--- a/tests/ghul-classlib/Directory.Packages.props
+++ b/tests/ghul-classlib/Directory.Packages.props
@@ -1,6 +1,9 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="ghul.runtime" Version="1.3.3" />
+    <PackageVersion Include="ghul.runtime" Version="3.0.1" />
     <PackageVersion Include="example.classlib" Version="0.0.1-alpha.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.2.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.2.0" />
   </ItemGroup>
 </Project>

--- a/tests/ghul-classlib/tests.ghulproj
+++ b/tests/ghul-classlib/tests.ghulproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+
     <PackageReference Include="example.classlib" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- bump `ghul.compiler` 0.8.35 → 1.0.3 and `ghul.runtime` 1.3.3 → 3.0.1 across both templates and the class library test harness
- give the class library test project a real test SDK and a source glob that matches `tests.ghul`, so `dotnet test` runs the example test instead of silently passing with nothing compiled
- derive the class library `PackageId` from the project name instead of hard-coding `example.classlib`
- classify the class library template as `Library`
- modernise the CI workflow: drop the disabled `set-output` command, the retired `ubuntu-20.04` runner and the archived `create-release`/`upload-release-asset` actions; use `dotnet new install`; checkout v4
- fix the Dependabot wrapper csproj import path

Verified locally: packed and installed the template package, instantiated both templates — console builds and prints `Hello world!`; class library builds, packs, and its test passes.