### PR TITLE
Replace degory/create-version with paulhatch/semantic-version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,29 +21,54 @@ env:
 
 jobs:
   version:
-    name: Create a version number
+    name: Determine the version number
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
-      tag: ${{ steps.create_version.outputs.tag }}
-      package: ${{ steps.create_version.outputs.package }}
+      tag: ${{ steps.package_version.outputs.tag }}
+      package: ${{ steps.package_version.outputs.package }}
 
     permissions:
-      contents: 'write'      
+      contents: read
 
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: '0'    
+        fetch-depth: '0'
 
-    - name: Create version
-      id: create_version
-      uses: degory/create-version@v0.0.2
+    # Calculates the next version from the git history. This action only
+    # reads the repository - it never creates tags or releases. The next
+    # version is a major/minor/patch bump of the most recent vX.Y.Z tag;
+    # a #major or #minor marker in a commit subject picks the bump level,
+    # otherwise each commit bumps the patch number.
+    - name: Calculate the semantic version
+      id: semver
+      uses: paulhatch/semantic-version@v6.0.2
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      env:
-        PRERELEASE: ${{ github.event_name == 'pull_request' }}
-        
+        tag_prefix: 'v'
+        major_pattern: '#major'
+        minor_pattern: '#minor'
+        version_format: '${major}.${minor}.${patch}'
+
+    - name: Determine the package version
+      id: package_version
+      run: |
+        manual="${{ github.event.inputs.version }}"
+        if [ -n "$manual" ]; then
+          # version supplied via the workflow_dispatch input
+          package="${manual#v}"
+        else
+          package="${{ steps.semver.outputs.version }}"
+          # pull request builds get a prerelease version so they can
+          # never collide with a real release
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            package="${package}-beta.${{ github.run_number }}"
+          fi
+        fi
+        echo "tag=v${package}" >> "$GITHUB_OUTPUT"
+        echo "package=${package}" >> "$GITHUB_OUTPUT"
+        echo "Version: v${package}"
+
   test-console-application:
     name: Test the console application in-situ
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switches the version job to a maintained, side-effect-free semantic version calculator. The release tag is now created only by the existing `gh release create` step on push to main; pull requests no longer push prerelease tags. Pull request builds get a `-beta.<run-number>` suffix to stay clear of real releases.

The previous wrapper (`degory/create-version` → `anothrNick/github-tag-action`) emitted the deprecated `::set-output` command and pushed tags as a side effect during version calculation. The new shape is the same as the one already in `ghul-repository-template` and aligns this repo's version job with the rest of the ghul* repos.